### PR TITLE
Include debug information in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ cortex-m-rt = "0.2.0"
 
 [profile.release]
 lto = true
+debug = true


### PR DESCRIPTION
Without debug information, `tbreak cortex_m_rt::reset_handler` does not work:
rustc does not include the Rust support script directive, gdb does not load it,
and breakpoints can only be set on functions using their full mangled name.