### PR TITLE
gdbinit: don't reset the microcontroller

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -4,6 +4,4 @@ monitor arm semihosting enable
 # monitor tpiu config internal itm.fifo uart off 8000000
 # monitor itm port 0 on
 load
-tbreak cortex_m_rt::reset_handler
-monitor reset halt
-continue
+step


### PR DESCRIPTION
simply `step` after the `load` command. This should just work now that we are
using cortex-m-rt v0.2.2