### PR TITLE
Remove 'monitor tpiu itm port 0 on' from .gdbinit

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -11,8 +11,5 @@ monitor arm semihosting enable
 # # 2000000 is the frequency of the SWO pin
 # monitor tpiu config external uart off 8000000 2000000
 
-# # enable ITM port 0
-# monitor itm port 0 on
-
 load
 step


### PR DESCRIPTION
This happens automatically when openocd sets up the tpiu; see openocd manual 16.5.4.