### PR TITLE
Revert "Remove 'monitor tpiu itm port 0 on' from .gdbinit"

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -11,5 +11,8 @@ monitor arm semihosting enable
 # # 2000000 is the frequency of the SWO pin
 # monitor tpiu config external uart off 8000000 2000000
 
+# # enable ITM port 0
+# monitor itm port 0 on
+
 load
 step


### PR DESCRIPTION
This reverts commit f88a44fd78ed111577e50d8765068ea9bf9919eb.

It's required on OpenOCD 0.10.0

cc @adamgreig I have been trying the latest quickstart version and ITM doesn't
work unless I add back this 'itm port 0 on' command. It seems to latch though
because if I run the command once then I don't need it anymore (unless I power
off the target device)