### PR TITLE
Build compiler-builtins from rust source instead of github repository.

### DIFF
--- a/Xargo.toml
+++ b/Xargo.toml
@@ -2,5 +2,4 @@
 stage = 0
 
 [dependencies.compiler_builtins]
-git = "https://github.com/rust-lang-nursery/compiler-builtins"
 stage = 1

--- a/examples/allocator.rs
+++ b/examples/allocator.rs
@@ -12,7 +12,6 @@
 //! stage = 0
 //!
 //! [dependencies.compiler_builtins]
-//! git = "https://github.com/rust-lang-nursery/compiler-builtins"
 //! stage = 1
 //! ```
 //!

--- a/src/examples/_6_allocator.rs
+++ b/src/examples/_6_allocator.rs
@@ -12,7 +12,6 @@
 //! stage = 0
 //!
 //! [dependencies.compiler_builtins]
-//! git = "https://github.com/rust-lang-nursery/compiler-builtins"
 //! stage = 1
 //! ```
 //!


### PR DESCRIPTION
Now, that rust switched to https://github.com/rust-lang-nursery/compiler-builtins, is there any reason to point to this repository in Xargo.toml? I tried and my projects working fine using compiler-builtins from rust-src.