### PR TITLE
use a single codegen-unit with the dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["arm", "cortex-m", "template"]
 license = "MIT OR Apache-2.0"
 name = "cortex-m-quickstart"
 repository = "https://github.com/japaric/cortex-m-quickstart"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 cortex-m = "0.3.0"
@@ -15,6 +15,9 @@ cortex-m-semihosting = "0.2.0"
 [dependencies.cortex-m-rt]
 features = ["abort-on-panic"]
 version = "0.3.3"
+
+[profile.dev]
+codegen-units = 1
 
 [profile.release]
 debug = true


### PR DESCRIPTION
rust-lang/rust#44853 changed the default number of codegen units from 1 to 32 for the dev profile.
Unfortunately this broke our dev builds so we are reverting the change in the Cargo.toml.

---

I haven't been able to figure the exact problem but things break at linking time. The related bits
are these:

1. We create a .vector_table.exceptions linker section in the cortex-m-rt crate.

``` rust
// cortex-m-rt/src/lib.rs
static EXCEPTIONS: [Option<unsafe extern "C" fn()>; 14] = [
    Some(NMI),
    Some(HARD_FAULT),
    Some(MEM_MANAGE),
    Some(BUS_FAULT),
    Some(USAGE_FAULT),
    None,
    None,
    None,
    None,
    Some(SVCALL),
    None,
    None,
    Some(PENDSV),
    Some(SYS_TICK),
];
```

2. We want this linker section to be available in all binaries that link to the cortex-m-rt crate so
we have a linker section, in the cortex-m-rt crate, that does that:

```
// link.x
SECTIONS
{
  .vector_table ORIGIN(FLASH) : ALIGN(4)
  {
    /* Vector table */
    _svector_table = .;
    LONG(_stack_start);

    KEEP(*(.vector_table.reset_vector));

    KEEP(*(.vector_table.exceptions));
    _eexceptions = .;

    KEEP(*(.vector_table.interrupts));
    _einterrupts = .;
  } > FLASH

  /* .. */
}
```

Now when compiling with either 1 or 32 codegen units the libcortex_m_rt.rlib library does contain
the EXCEPTIONS symbol and the symbol *is* placed in the right linker section. AFAICT, the only
different between using 1 or 32 codegen units is that the rlib contains more object files inside
when compiling with 32 codegen units.

My wild guess about what's happening is that since there are more object files the linker is *not*
looking at *all* of them so it never looks at the object file that contains the EXCEPTIONS symbol
and that's why it doesn't end up in the final binary.