### PR TITLE
gdbinit: print demangled symbols by default

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,5 +1,8 @@
 target remote :3333
 
+# print demangled symbols by default
+set print asm-demangle on
+
 monitor arm semihosting enable
 
 # # send captured ITM to the file itm.fifo


### PR DESCRIPTION
this change turns this:

``` console
(gdb) x/4 0x200003f0
0x200003f0 <_ZN3app2XS17h4b49405669958fd2E+1008>:       0x20000400      0x080004f5      0x00000000      0x00000001
```

into this:

``` console
(gdb) x/4 0x200003f0
0x200003f0 <app::XS+1008>:      0x20000400      0x080004f5      0x00000000      0x00000001
```