### PR TITLE
Update panic-semihosting dependency to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.3.1"
 cortex-m = "0.5.0"
 cortex-m-rt = "0.5.0"
 cortex-m-semihosting = "0.3.0"
-panic-semihosting = "0.2.0"
+panic-semihosting = "0.3.0"
 
 # Uncomment for the panic example.
 # panic-itm = "0.1.1"


### PR DESCRIPTION
This is due to #[lang = "panic_fmt"] -> #[panic_implementation] breakage